### PR TITLE
2022 10 11 updates

### DIFF
--- a/.github/workflows/scheduled-check.yaml
+++ b/.github/workflows/scheduled-check.yaml
@@ -28,7 +28,7 @@ jobs:
           --sitemap-url=https://www.mozilla.org/sitemap.xml
           --batch="${{ matrix.batch }}"
       - name: Upload output files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: scan-results
           path: output
@@ -53,7 +53,7 @@ jobs:
           --maintain-hostname
           --batch="${{ matrix.batch }}"
       - name: Upload output files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: scan-results
           path: output
@@ -78,7 +78,7 @@ jobs:
           --maintain-hostname
           --batch="${{ matrix.batch }}"
       - name: Upload output files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: scan-results
           path: output
@@ -98,7 +98,7 @@ jobs:
         run: pip install -r requirements.txt
       - name: Download artifacts, if they exist
         id: download-scan-results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: scan-results
           path: output

--- a/.github/workflows/scheduled-check.yaml
+++ b/.github/workflows/scheduled-check.yaml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check main CDN - batch ${{ matrix.batch }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
       - name: Install requirements
         run: pip install -r requirements.txt
       - name: Run checker
@@ -38,8 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check US origin server - batch ${{ matrix.batch }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
       - name: Install requirements
         run: pip install -r requirements.txt
       - name: Run checker
@@ -61,8 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check EU origin server - batch ${{ matrix.batch }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
       - name: Install requirements
         run: pip install -r requirements.txt
       - name: Run checker
@@ -84,8 +84,8 @@ jobs:
       - run_on_us_origin
       - run_on_eu_origin
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
       - name: Install requirements
         run: pip install -r requirements.txt
       - name: Download artifacts, if they exist

--- a/.github/workflows/scheduled-check.yaml
+++ b/.github/workflows/scheduled-check.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Install requirements
         run: pip install -r requirements.txt
       - name: Run checker
@@ -40,6 +42,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Install requirements
         run: pip install -r requirements.txt
       - name: Run checker
@@ -63,6 +67,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Install requirements
         run: pip install -r requirements.txt
       - name: Run checker
@@ -86,6 +92,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Install requirements
         run: pip install -r requirements.txt
       - name: Download artifacts, if they exist

--- a/data/allowlist.yaml
+++ b/data/allowlist.yaml
@@ -796,6 +796,7 @@ bedrock_base_config: &bedrock_base_config
     - https://firefox-dev.tools/
     - https://flathub.org/apps/details/org.mozilla.firefox
     - https://flic.kr/p/2j7GXpB
+    - https://fortune.com/40-under-40/2021/keyanna-schmiedl/
     - https://foundation.mozilla.org
     - https://foundeo.com/
     - https://friendsofglobalvoices.org/
@@ -1218,6 +1219,7 @@ bedrock_base_config: &bedrock_base_config
     - https://www.bloomberg.com/news/articles/2020-02-12/400-million-social-media-users-set-to-lose-anonymity-in-india
     - https://www.bugzilla.org
     - https://www.bugzilla.org/
+    - https://www.businessinsider.com/diversity-executives-transforming-corporate-america-post-george-floyd-2021
     - https://www.cbsnews.com/news/facebook-advertisers-pull-ads-mozilla-sonos/
     - https://www.ccadb.org/policy
     - https://www.ceps.eu/publications/software-vulnerability-disclosure-europe-technology-policies-and-legal-challenges

--- a/data/allowlist.yaml
+++ b/data/allowlist.yaml
@@ -1388,6 +1388,7 @@ bedrock_base_config: &bedrock_base_config
     - https://www.theverge.com/2018/9/30/17913712/california-net-neutrality-bill-signed-law-jerry-brown
     - https://www.tiktok.com/@mozilla
     - https://www.torproject.org/
+    - https://www.twilio.com
     - https://www.twitch.tv/p/legal/privacy-policy/
     - https://www.ubuntu.com/about/about-ubuntu/conduct
     - https://www.udemy.com/course/lean-data-practices/


### PR DESCRIPTION
* Allowlist update for www.twilio.com
* Update actions dependencies to use versions based on Node 16, because Node 12 is now deprecated