### PR TITLE
Make sure GH token is available to the gh cli tool

### DIFF
--- a/.github/workflows/mozorg-scheduled-check.yaml
+++ b/.github/workflows/mozorg-scheduled-check.yaml
@@ -108,3 +108,5 @@ jobs:
           path: output
       - name: Fail the job if scan-results exists
         run: python bin/handle_output.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Without this, the handle_output.py script was not able to raise a PR. Making it available via the env lets the GH cli tool act as an authenticated user