### PR TITLE
Automatic updates to allowlist - 2023-05-09T10:03:26

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ html5lib==1.1
 lxml==4.9.2
 pyaml-env==1.2.1
 requests==2.30.0
-ruamel.yaml==0.17.24
+ruamel.yaml==0.17.22
 sentry-sdk==1.22.2
 slack_sdk==3.21.3
 sqlparse==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -223,9 +223,9 @@ requests==2.30.0 \
     --hash=sha256:10e94cc4f3121ee6da529d358cdaeaff2f1c409cd377dbc72b825852f2f7e294 \
     --hash=sha256:239d7d4458afcb28a692cdd298d87542235f4ca8d36d03a15bfc128a6559a2f4
     # via -r requirements.in
-ruamel-yaml==0.17.24 \
-    --hash=sha256:90e398ee24524ebe20fc48cd1861cedd25520457b9a36cfb548613e57fde30a0 \
-    --hash=sha256:f251bd9096207af604af69d6495c3c650a3338d0493d27b04bc55477d7a884ed
+ruamel-yaml==0.17.22 \
+    --hash=sha256:b4c6e66d103d8af198aa6139580ab735169be4922eb4c515ac121bdabf6f9361 \
+    --hash=sha256:c22ec58aaca5105f771cb8f7ac45ad631b5e8b00454ebe1822d442fb696e9e62
     # via -r requirements.in
 ruamel-yaml-clib==0.2.7 \
     --hash=sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e \


### PR DESCRIPTION
While scanning the site, the following outbound URLs were detected in the site:


* https://hackerone.com/mozilla_critical_services/thanks
Found in:
  * /en-US/security/bug-bounty/faq-webapp/
* https://hackerone.com/mozilla_core_services
Found in:
  * /en-US/security/bug-bounty/web-hall-of-fame/
  * /en-US/security/bug-bounty/faq-webapp/
  * /en-US/security/web-bug-bounty/
* https://hackerone.com/mozilla_critical_services
Found in:
  * /en-US/security/bug-bounty/web-hall-of-fame/
  * /en-US/security/bug-bounty/faq-webapp/
  * /en-US/security/web-bug-bounty/
* https://hackerone.com/mozilla_core_services/thanks
Found in:
  * /en-US/security/bug-bounty/faq-webapp/



They have been automatically added to the allowlist, as featured in this pull request.

**Please do not just approve and merge without checking**

For each URL mentioned above:

* Does it work?
* Does it link somewhere appropriate?
* Could it be replaced with a regex? (If so, close this PR and open a new one where you edit 'allowed_outbound_url_regexes' in the allowlist)

Hopefully this PR saves you time and effort.

CheckerBot

--

Fingerprint: e5f1d66aebfcec55d54117b42800bd51
