### PR TITLE
Update sitemap URL to account for the change in mozilla/bedrock#16208

### DIFF
--- a/.github/workflows/mozorg-site-scanning.yaml
+++ b/.github/workflows/mozorg-site-scanning.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Run checker
         run: >
           python bin/scan_site.py
-          --sitemap-url="https://${{ secrets.MOZORG_CDN_HOSTNAME }}/sitemap.xml"
+          --sitemap-url="https://${{ secrets.MOZORG_CDN_HOSTNAME }}/all-urls.xml"
           --batch="${{ matrix.batch }}"
           --export-cache
       - name: Upload scan output files
@@ -73,7 +73,7 @@ jobs:
       - name: Run checker
         run: >
           python bin/scan_site.py
-          --sitemap-url="https://${{ secrets.MOZORG_US_ORIGIN_HOSTNAME }}/sitemap.xml"
+          --sitemap-url="https://${{ secrets.MOZORG_US_ORIGIN_HOSTNAME }}/all-urls.xml"
           --maintain-hostname
           --batch="${{ matrix.batch }}"
       - name: Upload scan output files
@@ -99,7 +99,7 @@ jobs:
       - name: Run checker
         run: >
           python bin/scan_site.py
-          --sitemap-url="https://${{ secrets.MOZORG_EU_ORIGIN_HOSTNAME }}/sitemap.xml"
+          --sitemap-url="https://${{ secrets.MOZORG_EU_ORIGIN_HOSTNAME }}/all-urls.xml"
           --maintain-hostname
           --batch="${{ matrix.batch }}"
       - name: Upload scan output files

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cd www-site-checker
 pip install -r requirements.txt
 export ALLOWLIST_FILEPATH=data/allowlist-mozorg.yaml
 export EXTRA_URLS_FILEPATH=data/extra-urls-mozorg.yaml
-python bin/scan_site.py --sitemap-url=https://www.mozilla.org/sitemap.xml
+python bin/scan_site.py --sitemap-url=https://www.mozilla.org/all-urls.xml
 ```
 
 The above will start to work through the entire sitemap (and child sitemaps) at that URL
@@ -57,7 +57,7 @@ If you only want to check a smaller batch of URLs (handy in development), add th
 
 ```bash
 # Only inspect batch three of all URLs to check, after slicing the site into 40 batches
-python bin/scan_site.py --sitemap-url=https://www.mozilla.org/sitemap.xml --batch=3:40
+python bin/scan_site.py --sitemap-url=https://www.mozilla.org/all-urls.xml --batch=3:40
 ```
 
 And if you only want to check a specific page, you use the `--specific-url` param. The following, for example, checks the homepage and a Fx mobile downbload page
@@ -69,7 +69,7 @@ python bin/scan_site.py --specific-url=https://www.mozilla.org/en-US/firefox/bro
 There is a default allowlist in use (`data/allowlist-mozorg.yaml` - **set via env vars**) but an alernative can be passed via the `--allowlist` param
 
 ```bash
-python bin/scan_site.py --sitemap-url=https://www.mozilla.org/sitemap.xml --allowlist=/path/to/custom/allowlist.yaml
+python bin/scan_site.py --sitemap-url=https://www.mozilla.org/all-urls.xml --allowlist=/path/to/custom/allowlist.yaml
 ```
 
 If you want or need to check a site whose sitemap points to a _different_ domain (eg you want to check an origin server whose sitemap is hard-coded to refer to the CDN domain, or a localhost setup) you should ensure the server is listed as an option in the allowlist and also pass the `--maintain-hostname` parameter.
@@ -77,19 +77,19 @@ If you want or need to check a site whose sitemap points to a _different_ domain
 For example:
 
 ```bash
-python bin/scan_site.py --sitemap-url=http://origin-server.example.com/sitemap.xml --maintain-hostname
+python bin/scan_site.py --sitemap-url=http://origin-server.example.com/all-urls.xml --maintain-hostname
 ```
 
 or, for localhost
 
 ```bash
-python bin/scan_site.py --sitemap-url=http://localhost:8000/sitemap.xml --maintain-hostname
+python bin/scan_site.py --sitemap-url=http://localhost:8000/all-urls.xml --maintain-hostname
 ```
 
 If you want to test the Sentry integration locally, you can pass a Sentry DSN as an environment variable. Here, we're passing a URL to [Kent - a local 'fake Sentry'](https://github.com/willkg/kent)
 
 ```bash
-SENTRY_DSN=http://public@127.0.0.1:8011/1 python bin/scan_site.py --sitemap-url=https://www.mozilla.org/sitemap.xml
+SENTRY_DSN=http://public@127.0.0.1:8011/1 python bin/scan_site.py --sitemap-url=https://www.mozilla.org/all-urls.xml
 ```
 
 ## The output files
@@ -125,4 +125,3 @@ If you come across an alert saying there was an unexpected URL detected and you'
 * Edit the allowlist - eg `data/allowlist-mozorg.yaml`
 * Run the checks locally (see above)
 * Push the branch up and raise a PR.
-

--- a/bin/robots_check.sh
+++ b/bin/robots_check.sh
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-if curl -s https://${HOSTNAME}/robots.txt | grep -q "Sitemap: https://www.mozilla.org/sitemap.xml";
+if curl -s https://${HOSTNAME}/robots.txt | grep -q "disallow: /*/whatsnew/";
 then
     echo "https://${HOSTNAME}/robots.txt is OK"
 else


### PR DESCRIPTION
See mozilla/bedrock#16208 . The checks here will fail until the URL change is rolled out for bedrock.