### PR TITLE
fix: ensure HTTP error issue creation is successful

### DIFF
--- a/bin/handle_site_scan_output.py
+++ b/bin/handle_site_scan_output.py
@@ -491,7 +491,11 @@ def main():
             http_errors, _action_url
         )
 
-    if unexpected_urls_found:
+    if unexpected_urls_found and http_errors_found:
+        message = "Unexpected outbound URL(s) and HTTP error(s) found when scanning site content.\nDetails and output: {}".format(
+            _action_url
+        )
+    elif unexpected_urls_found:
         message = "Unexpected outbound URL found when scanning site content.\nDetails and output: {}".format(
             _action_url
         )

--- a/bin/handle_site_scan_output.py
+++ b/bin/handle_site_scan_output.py
@@ -18,7 +18,12 @@ import requests
 import ruamel.yaml
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
-from utils import _print, get_output_path, ping_slack
+
+# Awkward hack to allow importing into tests
+try:
+    from utils import _print, get_output_path, ping_slack
+except ImportError:
+    from .utils import _print, get_output_path, ping_slack
 
 GITHUB_ACTION = os.environ.get("GITHUB_ACTION", "NO-ACTION-IN-USE")
 GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "NO-REPOSITORY-IN-USE")
@@ -41,6 +46,7 @@ SITE_CHECKER_ISSUES_API_URL = os.environ.get(
 )
 
 UNEXPECTED_URLS_FILENAME_FRAGMENT = "unexpected_urls_for"
+HTTP_ERRORS_FILENAME_FRAGMENT = "http_errors_for"
 
 
 def _load_template(filepath):
@@ -105,6 +111,104 @@ def _is_valid_url(url: str) -> bool:
 
 def _get_hashed_value(iterable: List) -> str:
     return sha512("-".join(sorted(iterable)).encode("utf-8")).hexdigest()[:32]
+
+
+def _load_http_errors(output_path: str) -> List[Dict]:
+    """Load and deduplicate HTTP errors from all batch output files."""
+    seen: set = set()
+    errors = []
+    for filename in os.listdir(output_path):
+        if HTTP_ERRORS_FILENAME_FRAGMENT in filename and filename.endswith(".json"):
+            with open(os.path.join(output_path, filename)) as fp:
+                batch_errors = json.load(fp)
+            for error in batch_errors:
+                key = (error["url"], error["status_code"])
+                if key not in seen:
+                    seen.add(key)
+                    errors.append(error)
+    return errors
+
+
+_HTTP_ERROR_LABELS: Dict = {
+    404: (
+        "Not Found",
+        "Please verify if this URL should exist or be removed from the sitemap.",
+    ),
+    502: ("Bad Gateway", "Please investigate the server issue."),
+    503: ("Service Unavailable", "Please investigate the server availability issue."),
+}
+
+
+def _create_http_error_issues(http_errors: List[Dict], action_url: str) -> List[str]:
+    """Create one consolidated GitHub issue per HTTP status code for errors found during scanning.
+
+    A single issue is opened per status code (e.g. one for all 404s), listing every
+    affected URL. The fingerprint is derived from the full sorted set of URLs so that
+    an identical set of failures on the next run won't re-open an already-open issue.
+    """
+    if not http_errors:
+        return []
+
+    output = []
+    current_issues = _get_current_github_issues()
+
+    # Group errors by status code, deduplicating URLs across batches/servers
+    errors_by_status: Dict[int, set] = {}
+    for error in http_errors:
+        errors_by_status.setdefault(error["status_code"], set()).add(error["url"])
+
+    for status_code, url_set in errors_by_status.items():
+        urls = sorted(url_set)
+        fingerprint = _get_hashed_value(urls)
+
+        already_exists = any(
+            fingerprint in (issue.get("body") or "") for issue in current_issues
+        )
+        if already_exists:
+            _print(
+                f"Skipping issue creation - existing {status_code} issue for this URL set already exists"
+            )
+            continue
+
+        error_name, description = _HTTP_ERROR_LABELS.get(
+            status_code, (f"Error {status_code}", "Please investigate this HTTP error.")
+        )
+
+        url_list = "\n".join(f"- {url}" for url in urls)
+        issue_title = f"{len(urls)} URL(s) returning {status_code} {error_name} errors"
+        issue_body = f"""{len(urls)} URL(s) returned a {status_code} {error_name} error during the latest site scan.
+
+**Error:** HTTP {status_code} {error_name}
+
+**Affected URLs:**
+{url_list}
+
+{description}
+
+**Scan details and artifacts:** {action_url}
+
+--
+
+Fingerprint: {fingerprint}"""
+
+        _print(f"Opening consolidated issue for {len(urls)} {status_code} error(s)")
+        result = subprocess.check_output(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--title",
+                issue_title,
+                "--body",
+                issue_body,
+                "--label",
+                "bug",
+            ],
+            stderr=subprocess.STDOUT,
+        )
+        output.append(result.decode())
+
+    return output
 
 
 def _get_current_github_prs() -> List:
@@ -175,11 +279,11 @@ def _update_allowlist(pr_candidates: List[str]) -> str:
         return output
 
     # 0. Make a new branch
-    os.system(f'git config user.email "{MEAO_IDENTITY_EMAIL}"')
-    os.system('git config user.name "www-site-checker bot"')
+    subprocess.run(["git", "config", "user.email", MEAO_IDENTITY_EMAIL], check=True)
+    subprocess.run(["git", "config", "user.name", "www-site-checker bot"], check=True)
 
     branchname = f'update-{allowlist_path.replace("/","-")}--{branch_timestamp}'
-    os.system(f"git switch -c {branchname}")
+    subprocess.run(["git", "switch", "-c", branchname], check=True)
 
     # 1. Update the allowlist
     yaml = ruamel.yaml.YAML()
@@ -195,11 +299,14 @@ def _update_allowlist(pr_candidates: List[str]) -> str:
 
     # 2. Commit it to git on the new branch
     # Only add the specific allowlist file to avoid committing unrelated changes
-    os.system(f'git add "{allowlist_path}"')
-    os.system(f'git commit -m "Automatic allowlist updates: {display_timestamp}"')
+    subprocess.run(["git", "add", allowlist_path], check=True)
+    subprocess.run(
+        ["git", "commit", "-m", f"Automatic allowlist updates: {display_timestamp}"],
+        check=True,
+    )
 
     # 3. Push the branch up to origin
-    os.system(f"git push origin {branchname}")
+    subprocess.run(["git", "push", "origin", branchname], check=True)
 
     # 4. Prepare the Pull Request
     pr_title = PR_TITLE_TEMPLATE.format(
@@ -209,13 +316,21 @@ def _update_allowlist(pr_candidates: List[str]) -> str:
         unexpected_urls_structured=unexpected_urls_structured,
         fingerprint=_get_hashed_value(pr_candidates),
     )
-    new_pr_command = (
-        f'gh pr create --head {branchname} --title "{pr_title}" --body "{pr_body}"'
-    )
     _print("Opening PR")
     try:
         output = subprocess.check_output(
-            new_pr_command, stderr=subprocess.STDOUT, shell=True
+            [
+                "gh",
+                "pr",
+                "create",
+                "--head",
+                branchname,
+                "--title",
+                pr_title,
+                "--body",
+                pr_body,
+            ],
+            stderr=subprocess.STDOUT,
         )
     except subprocess.CalledProcessError as e:
         _print(f"Failed to create PR: {e.output.decode()}")
@@ -273,10 +388,20 @@ def _open_new_issues(issue_candidates: List[str]) -> List[str]:
             ),
             fingerprint=_get_hashed_value([problematic_url]),
         )
-        new_issue_command = f'gh issue create --title "{issue_title}" --body "{issue_body}" --label "bug"'
         _print("Opening new issue")
         result = subprocess.check_output(
-            new_issue_command, stderr=subprocess.STDOUT, shell=True
+            [
+                "gh",
+                "issue",
+                "create",
+                "--title",
+                issue_title,
+                "--body",
+                issue_body,
+                "--label",
+                "bug",
+            ],
+            stderr=subprocess.STDOUT,
         )
         output.append(result.decode())
 
@@ -318,23 +443,24 @@ def raise_prs_or_issues(output_path: str) -> Dict:
 
 
 def main():
-    """Look for a report of unexpected URLs found during the scan.
-    If we find one, alert via Slack.
+    """Look for reports of unexpected URLs or HTTP errors found during the scan.
+    If we find any, alert via Slack.
 
     Note that a separate Sentry ping is sent up when the unexpected
     URLs are found, so the Slack message isn't the only alert.
     """
     message = ""
     output_path = get_output_path()
-    artifact_found = False
+    unexpected_urls_found = False
+    http_errors_found = False
 
-    # Do we have any artifacts available? If we _don't_, that's good news
     for filename in os.listdir(output_path):
         if UNEXPECTED_URLS_FILENAME_FRAGMENT in filename:
-            artifact_found = True
-            break
+            unexpected_urls_found = True
+        if HTTP_ERRORS_FILENAME_FRAGMENT in filename and filename.endswith(".json"):
+            http_errors_found = True
 
-    if not artifact_found:
+    if not unexpected_urls_found and not http_errors_found:
         _print("No artifact detected")
         return
 
@@ -342,28 +468,55 @@ def main():
         f"{GITHUB_SERVER_URL}/{GITHUB_REPOSITORY}/actions/runs/{GITHUB_RUN_ID}/"
     )
 
-    try:
-        github_urls = raise_prs_or_issues(output_path)
-    except OSError as ose:
-        _msg = f"Problem raising new PR or Issue: {ose}.\nDetails and artifacts at at {_action_url}"
-        if "Artifact list too long" in str(ose):
-            _msg = f"Problem raising new PR or Issue - too many entries to handle in one go, so needs manual curation.\nDetails and artifacts at at {_action_url}"
+    github_urls: Dict = {"pr_url": "", "issue_urls": [], "http_error_issue_urls": []}
 
-        _print(_msg)
-        ping_slack(_msg)
-        # we want to fail hard here, because it needs looking at.
-        sys.exit(1)
+    if unexpected_urls_found:
+        try:
+            result = raise_prs_or_issues(output_path)
+            github_urls["pr_url"] = result.get("pr_url", "")
+            github_urls["issue_urls"] = result.get("issue_urls", [])
+        except OSError as ose:
+            _msg = f"Problem raising new PR or Issue: {ose}.\nDetails and artifacts at at {_action_url}"
+            if "Artifact list too long" in str(ose):
+                _msg = f"Problem raising new PR or Issue - too many entries to handle in one go, so needs manual curation.\nDetails and artifacts at at {_action_url}"
 
-    message = "Unexpected outbound URL found when scanning site content.\nDetails and output: {}".format(
-        _action_url
-    )
+            _print(_msg)
+            ping_slack(_msg)
+            # we want to fail hard here, because it needs looking at.
+            sys.exit(1)
+
+    if http_errors_found:
+        http_errors = _load_http_errors(output_path)
+        github_urls["http_error_issue_urls"] = _create_http_error_issues(
+            http_errors, _action_url
+        )
+
+    if unexpected_urls_found:
+        message = "Unexpected outbound URL found when scanning site content.\nDetails and output: {}".format(
+            _action_url
+        )
+    else:
+        message = "HTTP error(s) found when scanning site content.\nDetails and output: {}".format(
+            _action_url
+        )
+
     if github_urls.get("pr_url"):
         message += "\nPR to amend allowlist: {}".format(github_urls["pr_url"])
     if github_urls.get("issue_urls"):
         message += "\nIssue(s) opened: \n{}".format(
             "\n".join(github_urls["issue_urls"])
         )
-    if not github_urls.get("pr_url") and not github_urls.get("issue_urls"):
+    if github_urls.get("http_error_issue_urls"):
+        message += "\nHTTP error issue(s) opened: \n{}".format(
+            "\n".join(github_urls["http_error_issue_urls"])
+        )
+    if not any(
+        [
+            github_urls.get("pr_url"),
+            github_urls.get("issue_urls"),
+            github_urls.get("http_error_issue_urls"),
+        ]
+    ):
         message += "\nNB: No new Issues or PRs opened - there will be existing ones on www-site-checker"
 
     _print(message)

--- a/bin/scan_site.py
+++ b/bin/scan_site.py
@@ -17,11 +17,9 @@ import logging
 import math
 import os
 import re
-import subprocess
 import time
 from collections import defaultdict
 from functools import cache
-from hashlib import sha512
 from typing import Dict, Iterable, List, Optional, Tuple
 from urllib.parse import quote, urlparse
 
@@ -32,7 +30,12 @@ from bs4 import BeautifulSoup
 from pyaml_env import parse_config
 from requests.exceptions import ChunkedEncodingError, ConnectionError, HTTPError
 from sentry_sdk.integrations.logging import LoggingIntegration
-from utils import _get_configuration_path, get_output_path
+
+# Awkward hack to allow importing into tests
+try:
+    from utils import _get_configuration_path, get_output_path
+except ImportError:
+    from .utils import _get_configuration_path, get_output_path
 
 GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "NO-REPOSITORY-IN-USE")
 SENTRY_DSN = os.environ.get("SENTRY_DSN")
@@ -54,6 +57,10 @@ if SENTRY_DSN:
 
 DEFAULT_BATCH__NOOP = "1_1"  # By default treat all URLs as a single batch
 UNEXPECTED_URLS_FILENAME_FRAGMENT = "unexpected_urls_for"
+HTTP_ERRORS_FILENAME_FRAGMENT = "http_errors_for"
+
+# Collected during the scan run; flushed to disk by _dump_http_errors_to_file()
+_HTTP_ERRORS: List[Dict] = []
 URL_RETRY_LIMIT = 3
 URL_RETRY_WAIT_SECONDS = 4
 
@@ -203,12 +210,14 @@ def check_for_unexpected_urls(
     click.echo("Checking pages for unexpected URLs")
     url_results = _check_pages_for_outbound_links(urls_to_check, allowlist_config)
 
+    batch_label = "all" if batch == DEFAULT_BATCH__NOOP else batch.split("_")[0]
+
     if url_results:
         click.echo(f"Unexpected outbound URLs found on {hostname}!")
         _dump_unexpected_urls_to_files(
             results=url_results,
             hostname=hostname,
-            batch_label="all" if batch == DEFAULT_BATCH__NOOP else batch.split("_")[0],
+            batch_label=batch_label,
         )
         if SENTRY_DSN:
             message = f"Unexpected oubound URLs found on {hostname} - see Github Action in {GITHUB_REPOSITORY} for output data"
@@ -218,6 +227,8 @@ def check_for_unexpected_urls(
             )
     else:
         click.echo("Checks completed and no unexpected outbound URLs found")
+
+    _dump_http_errors_to_file(hostname=hostname, batch_label=batch_label)
 
 
 def _get_batched_urls(urls_to_check: List[str], batch: str) -> List[str]:
@@ -243,65 +254,27 @@ def _page_content_is_cacheable(url):
     return False
 
 
-# Module-level cache for GitHub issues (prevents multiple API calls per scan run)
-_GITHUB_ISSUES_CACHE = None
+def _dump_http_errors_to_file(hostname: str, batch_label: str) -> None:
+    """Write HTTP errors collected during this scan run to a JSON file in the output directory.
 
-
-def _get_hashed_value_for_http_error(url: str, status_code: int) -> str:
-    """Create fingerprint for HTTP error issue.
-
-    Args:
-        url: The failing URL (redacted, just path/query)
-        status_code: HTTP status code
-
-    Returns:
-        First 32 chars of SHA512 hash
+    The file is picked up by handle_site_scan_output.py (which runs in a later job
+    that has the GH_TOKEN / issues:write permission needed to open GitHub issues).
     """
-    # Combine URL and status code for unique fingerprint
-    fingerprint_input = f"{url}-{status_code}"
-    return sha512(fingerprint_input.encode("utf-8")).hexdigest()[:32]
+    if not _HTTP_ERRORS:
+        return
 
+    _output_path = get_output_path()
+    _now = (
+        datetime.datetime.now(datetime.UTC)
+        .isoformat(timespec="seconds")
+        .replace(":", "-")
+    )
+    filename = f"{HTTP_ERRORS_FILENAME_FRAGMENT}_{hostname}_{batch_label}_{_now}.json"
+    filepath = os.path.join(_output_path, filename)
 
-def _get_current_github_issues() -> List:
-    """Fetch list of open issues from GitHub API (cached per process)."""
-    global _GITHUB_ISSUES_CACHE
-
-    # Return cached results if available
-    if _GITHUB_ISSUES_CACHE is not None:
-        return _GITHUB_ISSUES_CACHE
-
-    github_repo = os.environ.get("GITHUB_REPOSITORY", "mozmeao/www-site-checker")
-    api_url = f"https://api.github.com/repos/{github_repo}/issues"
-
-    try:
-        response = requests.get(api_url)
-        response.raise_for_status()
-        _GITHUB_ISSUES_CACHE = response.json()
-        return _GITHUB_ISSUES_CACHE
-    except requests.RequestException as e:
-        click.echo(f"Warning: Could not fetch existing issues: {e}")
-        return []
-
-
-def _matching_http_error_issue_exists(url: str, status_code: int) -> bool:
-    """Check if an issue already exists for this HTTP error.
-
-    Args:
-        url: The failing URL (redacted)
-        status_code: HTTP status code
-
-    Returns:
-        True if matching issue exists, False otherwise
-    """
-    fingerprint = _get_hashed_value_for_http_error(url, status_code)
-    current_issues = _get_current_github_issues()
-
-    for issue in current_issues:
-        body = issue.get("body", "")
-        if body and fingerprint in body:
-            return True
-
-    return False
+    with open(filepath, "w") as fp:
+        json.dump(_HTTP_ERRORS, fp)
+    click.echo(f"{len(_HTTP_ERRORS)} HTTP error(s) written to {filepath}")
 
 
 def _strip_hostname_from_url(url: str) -> str:
@@ -315,88 +288,25 @@ def _strip_hostname_from_url(url: str) -> str:
     return result if result else "/"
 
 
-def _create_http_error_issue(url: str, status_code: int, retry_count: int = 0) -> None:
-    """Create a GitHub issue for a URL that returns an HTTP error.
+def _record_http_error(url: str, status_code: int) -> None:
+    """Record an HTTP error encountered during scanning.
 
-    Args:
-        url: The URL that failed
-        status_code: The HTTP status code (e.g., 404, 502)
-        retry_count: Number of retries attempted (0 if not retried)
+    Errors are collected in _HTTP_ERRORS and written to a file at the end of the
+    scan run by _dump_http_errors_to_file(). The file is then picked up by
+    handle_site_scan_output.py, which runs in a job with the necessary GitHub
+    permissions to open issues.
     """
     redacted_url = _strip_hostname_from_url(url)
-
-    # Check if issue already exists
-    if _matching_http_error_issue_exists(redacted_url, status_code):
-        click.echo(
-            f"Skipping issue creation - existing {status_code} issue for {redacted_url} already exists"
-        )
-        return
-
-    # Map status codes to error names and descriptions
-    error_info = {
-        404: {
-            "name": "Not Found",
-            "description": "Please verify if this URL should exist or be removed from the sitemap.",
-        },
-        502: {
-            "name": "Bad Gateway",
-            "description": "Please investigate the server issue.",
-        },
-        503: {
-            "name": "Service Unavailable",
-            "description": "Please investigate the server availability issue.",
-        },
-    }
-
-    info = error_info.get(
-        status_code,
+    _HTTP_ERRORS.append(
         {
-            "name": f"Error {status_code}",
-            "description": "Please investigate this HTTP error.",
-        },
+            "url": redacted_url,
+            "status_code": status_code,
+            "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+        }
     )
-
-    try:
-        retry_text = f" after {retry_count} retries" if retry_count > 0 else ""
-        fingerprint = _get_hashed_value_for_http_error(redacted_url, status_code)
-
-        issue_title = f"{status_code} {info['name']} error on {redacted_url}"
-        issue_body = f"""A {status_code} {info["name"]} error occurred when attempting to scan this URL{retry_text}.
-
-**URL:** {redacted_url}
-
-**Error:** HTTP {status_code} {info["name"]}
-
-**Timestamp:** {datetime.datetime.now(datetime.UTC).isoformat()}Z
-
-This page was skipped during the scan. {info["description"]}
-
---
-
-Fingerprint: {fingerprint}"""
-
-        # Escape quotes in the issue body for shell command
-        issue_body_escaped = issue_body.replace('"', '\\"').replace("$", "\\$")
-
-        command = f'gh issue create --title "{issue_title}" --body "{issue_body_escaped}" --label "bug"'
-        result = subprocess.run(
-            command,
-            shell=True,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        click.echo(f"Created issue for {status_code} error: {result.stdout.strip()}")
-    except subprocess.CalledProcessError as e:
-        click.echo(
-            f"Failed to create issue for {status_code} error on {url}: {e.stderr}"
-        )
-        sentry_sdk.capture_exception(e)
-    except Exception as e:
-        click.echo(
-            f"Unexpected error creating issue for {status_code} error on {url}: {e}"
-        )
-        sentry_sdk.capture_exception(e)
+    click.echo(
+        f"Recorded {status_code} error for {redacted_url} (issue will be opened after scan completes)"
+    )
 
 
 def _get_url_with_retry(
@@ -440,10 +350,10 @@ def _get_url_with_retry(
         ):
             status_code = re.response.status_code
 
-        # For 404 errors, don't retry - just create an issue and continue
+        # For 404 errors, don't retry - just record and continue
         if status_code == 404:
-            click.echo(f"404 Not Found error for {url}. Creating issue and continuing.")
-            _create_http_error_issue(url, status_code, retry_count=0)
+            click.echo(f"404 Not Found error for {url}. Recording for issue creation.")
+            _record_http_error(url, status_code)
             return None
 
         if try_count < limit:
@@ -457,11 +367,11 @@ def _get_url_with_retry(
         else:
             # Max retries reached
             if status_code in (502, 503):
-                # Create a GitHub issue for server errors and continue
+                # Record the server error for issue creation and continue
                 click.echo(
-                    f"Max retries ({URL_RETRY_LIMIT}) reached with {status_code} error for {url}. Creating issue and continuing."
+                    f"Max retries ({URL_RETRY_LIMIT}) reached with {status_code} error for {url}. Recording for issue creation."
                 )
-                _create_http_error_issue(url, status_code, retry_count=URL_RETRY_LIMIT)
+                _record_http_error(url, status_code)
                 return None
             else:
                 # For other errors, raise the exception

--- a/tests/test_handle_site_scan_output.py
+++ b/tests/test_handle_site_scan_output.py
@@ -1,0 +1,148 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import json
+from unittest.mock import patch
+
+from bin.handle_site_scan_output import (
+    _create_http_error_issues,
+    _get_hashed_value,
+    _load_http_errors,
+)
+
+
+class TestLoadHttpErrors:
+    def test_deduplicates_same_url_across_batch_files(self, tmp_path):
+        batch1 = [{"url": "/missing/", "status_code": 404, "timestamp": "T1"}]
+        batch2 = [
+            {"url": "/missing/", "status_code": 404, "timestamp": "T2"},
+            {"url": "/other/", "status_code": 404, "timestamp": "T2"},
+        ]
+        (tmp_path / "http_errors_for_cdn_1_2026.json").write_text(json.dumps(batch1))
+        (tmp_path / "http_errors_for_cdn_2_2026.json").write_text(json.dumps(batch2))
+
+        result = _load_http_errors(str(tmp_path))
+
+        assert {(e["url"], e["status_code"]) for e in result} == {
+            ("/missing/", 404),
+            ("/other/", 404),
+        }
+
+    def test_ignores_unexpected_url_json_files(self, tmp_path):
+        (tmp_path / "unexpected_urls_for_cdn_structured.json").write_text(
+            json.dumps({})
+        )
+        assert _load_http_errors(str(tmp_path)) == []
+
+    def test_returns_empty_when_no_files(self, tmp_path):
+        assert _load_http_errors(str(tmp_path)) == []
+
+    def test_same_url_different_status_codes_kept_separately(self, tmp_path):
+        batch = [
+            {"url": "/flaky/", "status_code": 404, "timestamp": "T"},
+            {"url": "/flaky/", "status_code": 502, "timestamp": "T"},
+        ]
+        (tmp_path / "http_errors_for_cdn_1_2026.json").write_text(json.dumps(batch))
+
+        result = _load_http_errors(str(tmp_path))
+        assert len(result) == 2
+
+
+class TestCreateHttpErrorIssues:
+    def test_creates_one_issue_per_status_code(self):
+        errors = [
+            {"url": "/a/", "status_code": 404, "timestamp": "T"},
+            {"url": "/b/", "status_code": 404, "timestamp": "T"},
+            {"url": "/c/", "status_code": 502, "timestamp": "T"},
+        ]
+        with (
+            patch(
+                "bin.handle_site_scan_output._get_current_github_issues",
+                return_value=[],
+            ),
+            patch(
+                "subprocess.check_output",
+                return_value=b"https://github.com/org/repo/issues/1\n",
+            ) as mock_gh,
+        ):
+            result = _create_http_error_issues(errors, "https://actions/run/1")
+
+        assert len(result) == 2  # one for 404s, one for 502
+        assert mock_gh.call_count == 2
+
+    def test_skips_when_fingerprint_already_in_open_issue(self):
+        errors = [{"url": "/gone/", "status_code": 404, "timestamp": "T"}]
+        fingerprint = _get_hashed_value(["/gone/"])
+        existing_issues = [{"body": f"Some text\n\nFingerprint: {fingerprint}"}]
+
+        with (
+            patch(
+                "bin.handle_site_scan_output._get_current_github_issues",
+                return_value=existing_issues,
+            ),
+            patch("subprocess.check_output") as mock_gh,
+        ):
+            result = _create_http_error_issues(errors, "https://actions/run/1")
+
+        assert result == []
+        mock_gh.assert_not_called()
+
+    def test_returns_empty_list_for_no_errors(self):
+        with patch(
+            "bin.handle_site_scan_output._get_current_github_issues", return_value=[]
+        ):
+            result = _create_http_error_issues([], "https://actions/run/1")
+        assert result == []
+
+    def test_issue_body_contains_all_affected_urls(self):
+        errors = [
+            {"url": "/en-US/missing/", "status_code": 404, "timestamp": "T"},
+            {"url": "/fr/missing/", "status_code": 404, "timestamp": "T"},
+        ]
+        captured = []
+
+        def fake_check_output(cmd, **kwargs):
+            captured.append(cmd)
+            return b"https://github.com/org/repo/issues/99\n"
+
+        with (
+            patch(
+                "bin.handle_site_scan_output._get_current_github_issues",
+                return_value=[],
+            ),
+            patch("subprocess.check_output", side_effect=fake_check_output),
+        ):
+            _create_http_error_issues(errors, "https://actions/run/42")
+
+        assert len(captured) == 1
+        args = captured[0]
+        body = args[args.index("--body") + 1]
+        assert "/en-US/missing/" in body
+        assert "/fr/missing/" in body
+        assert "https://actions/run/42" in body
+
+    def test_issue_title_includes_count_and_status_code(self):
+        errors = [
+            {"url": "/a/", "status_code": 404, "timestamp": "T"},
+            {"url": "/b/", "status_code": 404, "timestamp": "T"},
+        ]
+        captured = []
+
+        def fake_check_output(cmd, **kwargs):
+            captured.append(cmd)
+            return b"https://github.com/org/repo/issues/5\n"
+
+        with (
+            patch(
+                "bin.handle_site_scan_output._get_current_github_issues",
+                return_value=[],
+            ),
+            patch("subprocess.check_output", side_effect=fake_check_output),
+        ):
+            _create_http_error_issues(errors, "https://actions/run/1")
+
+        args = captured[0]
+        title = args[args.index("--title") + 1]
+        assert "2" in title  # URL count
+        assert "404" in title

--- a/tests/test_link_checker.py
+++ b/tests/test_link_checker.py
@@ -1,3 +1,74 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import json
+from unittest.mock import patch
+
+import bin.scan_site as scan_site
+
+
+class TestRecordHttpError:
+    def setup_method(self):
+        scan_site._HTTP_ERRORS.clear()
+
+    def teardown_method(self):
+        scan_site._HTTP_ERRORS.clear()
+
+    def test_appends_error_with_correct_shape(self):
+        scan_site._record_http_error("https://www.mozilla.org/en-US/missing/", 404)
+        assert len(scan_site._HTTP_ERRORS) == 1
+        error = scan_site._HTTP_ERRORS[0]
+        assert error["url"] == "/en-US/missing/"
+        assert error["status_code"] == 404
+        assert "timestamp" in error
+
+    def test_strips_hostname_and_preserves_query_string(self):
+        scan_site._record_http_error("https://cdn.example.com/some/path?q=1", 404)
+        assert scan_site._HTTP_ERRORS[0]["url"] == "/some/path?q=1"
+
+    def test_accumulates_multiple_errors(self):
+        scan_site._record_http_error("https://www.mozilla.org/a/", 404)
+        scan_site._record_http_error("https://www.mozilla.org/b/", 502)
+        assert len(scan_site._HTTP_ERRORS) == 2
+        assert scan_site._HTTP_ERRORS[0]["status_code"] == 404
+        assert scan_site._HTTP_ERRORS[1]["status_code"] == 502
+
+
+class TestDumpHttpErrorsToFile:
+    def setup_method(self):
+        scan_site._HTTP_ERRORS.clear()
+
+    def teardown_method(self):
+        scan_site._HTTP_ERRORS.clear()
+
+    def test_no_file_written_when_no_errors(self, tmp_path):
+        with patch("bin.scan_site.get_output_path", return_value=str(tmp_path)):
+            scan_site._dump_http_errors_to_file("example.com", "1")
+        assert list(tmp_path.iterdir()) == []
+
+    def test_writes_json_file_with_correct_content(self, tmp_path):
+        scan_site._HTTP_ERRORS.append(
+            {"url": "/gone/", "status_code": 404, "timestamp": "2026-01-01T00:00:00"}
+        )
+        with patch("bin.scan_site.get_output_path", return_value=str(tmp_path)):
+            scan_site._dump_http_errors_to_file("example.com", "3")
+
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1
+        assert files[0].name.startswith("http_errors_for_example.com_3_")
+        assert files[0].name.endswith(".json")
+        data = json.loads(files[0].read_text())
+        assert data == [
+            {"url": "/gone/", "status_code": 404, "timestamp": "2026-01-01T00:00:00"}
+        ]
+
+    def test_filename_uses_batch_label(self, tmp_path):
+        scan_site._HTTP_ERRORS.append(
+            {"url": "/x/", "status_code": 404, "timestamp": "2026-01-01T00:00:00"}
+        )
+        with patch("bin.scan_site.get_output_path", return_value=str(tmp_path)):
+            scan_site._dump_http_errors_to_file("cdn.mozilla.net", "5")
+
+        files = list(tmp_path.iterdir())
+        assert "cdn.mozilla.net_5_" in files[0].name


### PR DESCRIPTION
## Summary

- `scan_site.py` was calling `gh issue create` inside the scan jobs (`run_on_cdn` etc.), which have no `GH_TOKEN` and only `contents: read` permission — so every attempt failed with a `CalledProcessError` that was silently caught and sent to Sentry
- During scanning, HTTP errors are now recorded to a JSON file in `output/` (one per batch, same artifact pattern as unexpected-URL results)
- `handle_site_scan_output.py` picks these up in the `alert_if_report_files_exist` job (where `GH_TOKEN` and `issues: write` are already set) and opens **one consolidated issue per status code**, listing all affected URLs — avoiding the potential spam of ~90 issues for a single missing route across locales
- The fingerprint is derived from the full sorted set of affected URLs, so an identical failure on the next run won't re-open an already-open issue
- Also fixes shell injection across all `gh`/`git` subprocess calls in `handle_site_scan_output.py`: replaces `shell=True` + manual quote-escaping with argument lists passed directly to `subprocess`

## Test plan

- [x] 17 tests passing (`pytest tests/`)
- [x] Trigger a manual workflow run and confirm a 404 results in a GH issue being opened in the `alert_if_report_files_exist` job