### PR TITLE
feat: check outbound links from cached HTML for 404 / 5xx errors

### DIFF
--- a/.github/workflows/firefox-external-link-check.yaml
+++ b/.github/workflows/firefox-external-link-check.yaml
@@ -1,0 +1,80 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# NB this workflow needs a cache of HTML documents, emitted by the main
+# site-scanning workflow for the CDN origin only
+
+name: "Check www.firefox.com for broken outbound links"
+
+permissions:
+  contents: read
+  actions: read  # needed to download artifacts from the completed workflow_run
+
+env:
+  SLACK_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK_URL }}
+
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows:
+      - www.firefox.com site scanning
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  check_outbound_links:
+    name: Check outbound links from cache
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read  # needed to download artifacts from the completed workflow_run
+      issues: write  # needed to file broken-link issues
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Download page cache
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchedArtifacts = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name.includes('html-cache-firefox');
+            });
+            let fs = require('fs');
+            for (const [i, artifact] of matchedArtifacts.entries()) {
+              let download = await github.rest.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: artifact.id,
+                 archive_format: 'zip',
+              });
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/page_cache/html-cache_${i}.zip`, Buffer.from(download.data));
+            }
+      - name: Unzip page cache
+        run: |
+          cd page_cache
+          unzip -o '*.zip'
+          ls -la
+      - name: Install requirements
+        run: pip install -r requirements.txt
+      - name: Check outbound links
+        env:
+          FXC_CDN_HOSTNAME: ${{ secrets.FXC_CDN_HOSTNAME }}
+          USER_AGENT: Mozilla/5.0 (Automated; https://github.com/mozmeao/www-site-checker) CheckerBot/1.0
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          python bin/check_links_in_cached_pages.py
+          --site-label=www.firefox.com
+          --in-scope-hostname="$FXC_CDN_HOSTNAME"

--- a/.github/workflows/mozorg-external-link-check.yaml
+++ b/.github/workflows/mozorg-external-link-check.yaml
@@ -1,0 +1,82 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# NB this workflow needs a cache of HTML documents, emitted by the main
+# site-scanning workflow for the CDN origin only
+
+name: "Check www.mozilla.org for broken outbound links"
+
+permissions:
+  contents: read
+  actions: read  # needed to download artifacts from the completed workflow_run
+
+env:
+  SLACK_NOTIFICATION_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK_URL }}
+
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows:
+      - www.mozilla.org site scanning
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  check_outbound_links:
+    name: Check outbound links from cache
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read  # needed to download artifacts from the completed workflow_run
+      issues: write  # needed to file broken-link issues
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Download page cache
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            // Match mozorg page cache only (e.g. html-cache-1_8); skip
+            // html-cache-firefox-* so this workflow stays site-scoped.
+            let matchedArtifacts = allArtifacts.data.artifacts.filter((artifact) => {
+              return /^html-cache-\d/.test(artifact.name);
+            });
+            let fs = require('fs');
+            for (const [i, artifact] of matchedArtifacts.entries()) {
+              let download = await github.rest.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: artifact.id,
+                 archive_format: 'zip',
+              });
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/page_cache/html-cache_${i}.zip`, Buffer.from(download.data));
+            }
+      - name: Unzip page cache
+        run: |
+          cd page_cache
+          unzip -o '*.zip'
+          ls -la
+      - name: Install requirements
+        run: pip install -r requirements.txt
+      - name: Check outbound links
+        env:
+          MOZORG_CDN_HOSTNAME: ${{ secrets.MOZORG_CDN_HOSTNAME }}
+          USER_AGENT: Mozilla/5.0 (Automated; https://github.com/mozmeao/www-site-checker) CheckerBot/1.0
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          python bin/check_links_in_cached_pages.py
+          --site-label=www.mozilla.org
+          --in-scope-hostname="$MOZORG_CDN_HOSTNAME"

--- a/bin/check_links_in_cached_pages.py
+++ b/bin/check_links_in_cached_pages.py
@@ -1,0 +1,386 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Check links found in cached HTML pages for 404 / 5xx responses.
+
+Runs in a workflow_run-triggered workflow after a site-scanning run completes.
+Loads the page_cache/ dump produced by scan_site.py --export-cache, extracts
+every <a>/<script>/<link> URL, fetches each one, and opens a GitHub issue per
+status code (404 / 5xx) listing the dead links and the pages they appear on.
+"""
+
+import json
+import os
+import subprocess
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from hashlib import sha512
+from typing import Dict, List, Optional, Set
+from urllib.parse import unquote, urljoin, urlparse, urlunparse
+
+import click
+import requests
+from bs4 import BeautifulSoup
+
+# Awkward hack to allow importing into tests
+try:
+    from utils import _print, load_html_pages, ping_slack
+except ImportError:
+    from .utils import _print, load_html_pages, ping_slack
+
+GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "NO-REPOSITORY-IN-USE")
+GITHUB_SERVER_URL = os.environ.get("GITHUB_SERVER_URL", "NO-GITHUB")
+GITHUB_RUN_ID = os.environ.get("GITHUB_RUN_ID", "NO-RUN-NUMBER")
+USER_AGENT = os.environ.get("USER_AGENT")
+
+SITE_CHECKER_ISSUES_API_URL = os.environ.get(
+    "SITE_CHECKER_ISSUES_API_URL",
+    "https://api.github.com/repos/mozmeao/www-site-checker/issues",
+)
+
+PAGE_CACHE_DIR = "page_cache"
+REQUEST_TIMEOUT_SECONDS = 15
+RETRY_WAIT_SECONDS = 4
+MAX_RETRIES_FOR_5XX = 1
+DEFAULT_CONCURRENCY = 10
+
+# Hrefs we never try to fetch
+SKIP_SCHEMES = ("mailto:", "tel:", "javascript:", "data:", "ftp:")
+
+ERROR_STATUS_LABELS = {
+    404: "Not Found",
+    500: "Internal Server Error",
+    501: "Not Implemented",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+}
+
+
+def _is_reportable_status(status_code: int) -> bool:
+    return status_code == 404 or 500 <= status_code < 600
+
+
+def _filename_to_url(filename: str) -> str:
+    """Best-effort reverse of scan_site._export_cache filename encoding.
+
+    Encoding was: quote(url).replace("/", "_") + optional ".html" suffix on
+    paths that originally ended in "/". The "_.html" suffix is therefore the
+    tell that the original URL ended with a slash (since the trailing "/"
+    became "_" before ".html" was appended). A natural ".html" in the URL
+    path is preceded by "_" representing the prior "/", so it shows up as
+    "_foo.html" and we keep the ".html".
+    """
+    if filename.endswith("_.html"):
+        core = filename[: -len(".html")]
+        return unquote(core.replace("_", "/"))
+    return unquote(filename.replace("_", "/"))
+
+
+def _strip_fragment(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.fragment:
+        parsed = parsed._replace(fragment="")
+        return urlunparse(parsed)
+    return url
+
+
+def _collect_links_from_cache(cache_dir: str) -> Dict[str, Set[str]]:
+    """Walk every cached HTML page and return {link_url: {page_url, ...}}."""
+    links: Dict[str, Set[str]] = defaultdict(set)
+    pages = load_html_pages(cache_dir)
+    _print(f"Loaded {len(pages)} cached HTML page(s) from {cache_dir}")
+
+    for filename, html in pages.items():
+        page_url = _filename_to_url(filename)
+        soup = BeautifulSoup(html, "html5lib")
+        for tag_name, attr in (
+            ("a", "href"),
+            ("script", "src"),
+            ("link", "href"),
+            ("link", "src"),
+        ):
+            for node in soup.find_all(tag_name):
+                raw = node.attrs.get(attr)
+                if not raw:
+                    continue
+                href = raw.strip()
+                if not href or href.startswith("#"):
+                    continue
+                if href.lower().startswith(SKIP_SCHEMES):
+                    continue
+                absolute = _strip_fragment(urljoin(page_url, href))
+                parsed = urlparse(absolute)
+                if parsed.scheme not in ("http", "https"):
+                    continue
+                if not parsed.netloc:
+                    continue
+                links[absolute].add(page_url)
+    return links
+
+
+def _check_url(url: str) -> Optional[int]:
+    """Return the final status code of `url`, or None on transport failure."""
+    headers = {"User-Agent": USER_AGENT} if USER_AGENT else {}
+    for attempt in range(MAX_RETRIES_FOR_5XX + 1):
+        try:
+            resp = requests.head(
+                url,
+                headers=headers,
+                allow_redirects=True,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            # Some servers refuse HEAD; retry with GET.
+            if resp.status_code in (405, 501):
+                resp = requests.get(
+                    url,
+                    headers=headers,
+                    allow_redirects=True,
+                    timeout=REQUEST_TIMEOUT_SECONDS,
+                    stream=True,
+                )
+                resp.close()
+            status = resp.status_code
+        except requests.RequestException as exc:
+            _print(f"transport error for {url}: {exc}")
+            return None
+
+        if 500 <= status < 600 and attempt < MAX_RETRIES_FOR_5XX:
+            time.sleep(RETRY_WAIT_SECONDS)
+            continue
+        return status
+    return None
+
+
+def _redact_page_url(url: str, in_scope_hostname: str) -> str:
+    """If `url` shares the in-scope hostname, drop scheme+host for compactness."""
+    parsed = urlparse(url)
+    if parsed.netloc == in_scope_hostname:
+        result = parsed.path or "/"
+        if parsed.query:
+            result += f"?{parsed.query}"
+        return result
+    return url
+
+
+def _check_links_concurrently(
+    links: Dict[str, Set[str]],
+    concurrency: int,
+) -> List[Dict]:
+    """Check every link in parallel; return one record per reportable error."""
+    errors: List[Dict] = []
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = {pool.submit(_check_url, url): url for url in links}
+        for future in as_completed(futures):
+            url = futures[future]
+            status = future.result()
+            if status is not None and _is_reportable_status(status):
+                errors.append(
+                    {
+                        "url": url,
+                        "status_code": status,
+                        "containing_pages": sorted(links[url]),
+                    }
+                )
+    return errors
+
+
+def _site_scoped_fingerprint(site_label: str, urls: List[str]) -> str:
+    """Hash that scopes dedup to one site so a 404 on example.org/dead found
+    by mozorg doesn't suppress the same finding on firefox.com."""
+    parts = [site_label] + sorted(urls)
+    return sha512("-".join(parts).encode("utf-8")).hexdigest()[:32]
+
+
+def _get_current_github_issues() -> List:
+    try:
+        resp = requests.get(SITE_CHECKER_ISSUES_API_URL)
+        return json.loads(resp.content)
+    except (requests.RequestException, json.JSONDecodeError) as exc:
+        _print(f"could not fetch current issues: {exc}")
+        return []
+
+
+def _build_issue_body(
+    site_label: str,
+    status_code: int,
+    error_records: List[Dict],
+    action_url: str,
+    in_scope_hostname: str,
+    fingerprint: str,
+) -> str:
+    label = ERROR_STATUS_LABELS.get(status_code, f"HTTP {status_code}")
+    urls = sorted({r["url"] for r in error_records})
+    pages_by_url = {r["url"]: r["containing_pages"] for r in error_records}
+
+    lines = [
+        f"{len(urls)} outbound link(s) returned {status_code} {label} when checked "
+        f"from the cached HTML for **{site_label}**.",
+        "",
+        "**Affected URLs:**",
+    ]
+    for url in urls:
+        lines.append(f"- {url}")
+        lines.append("  Found on:")
+        for page_url in pages_by_url.get(url, []):
+            redacted = _redact_page_url(page_url, in_scope_hostname)
+            lines.append(f"  - {redacted}")
+    lines += [
+        "",
+        f"**Scan details and artifacts:** {action_url}",
+        "",
+        "--",
+        "",
+        f"Fingerprint: {fingerprint}",
+    ]
+    return "\n".join(lines)
+
+
+def _open_issue_for_status_code(
+    site_label: str,
+    status_code: int,
+    error_records: List[Dict],
+    action_url: str,
+    in_scope_hostname: str,
+    current_issues: List[Dict],
+) -> Optional[str]:
+    urls = sorted({r["url"] for r in error_records})
+    fingerprint = _site_scoped_fingerprint(site_label, urls)
+
+    if any(fingerprint in (issue.get("body") or "") for issue in current_issues):
+        _print(
+            f"Skipping {status_code} issue for {site_label}: fingerprint already in an open issue"
+        )
+        return None
+
+    label = ERROR_STATUS_LABELS.get(status_code, f"HTTP {status_code}")
+    title = (
+        f"{site_label}: {len(urls)} outbound link(s) returning {status_code} {label}"
+    )
+    body = _build_issue_body(
+        site_label=site_label,
+        status_code=status_code,
+        error_records=error_records,
+        action_url=action_url,
+        in_scope_hostname=in_scope_hostname,
+        fingerprint=fingerprint,
+    )
+
+    _print(f"Opening issue for {len(urls)} {status_code} error(s) on {site_label}")
+    result = subprocess.check_output(
+        [
+            "gh",
+            "issue",
+            "create",
+            "--title",
+            title,
+            "--body",
+            body,
+            "--label",
+            "bug",
+        ],
+        stderr=subprocess.STDOUT,
+    )
+    return result.decode().strip()
+
+
+@click.command()
+@click.option(
+    "--site-label",
+    required=True,
+    help="Human-friendly site identifier used in issue titles and fingerprints (e.g. www.mozilla.org)",
+)
+@click.option(
+    "--in-scope-hostname",
+    default=None,
+    help="Hostname whose pages get their scheme+host stripped in 'Found on' lists. Defaults to --site-label.",
+)
+@click.option(
+    "--cache-dir",
+    default=PAGE_CACHE_DIR,
+    help="Directory containing the dumped HTML pages",
+)
+@click.option(
+    "--concurrency",
+    default=DEFAULT_CONCURRENCY,
+    type=int,
+)
+@click.option(
+    "--no-issues",
+    is_flag=True,
+    default=False,
+    help="If set, just report findings to stdout and skip GitHub issue creation",
+)
+def main(
+    site_label: str,
+    in_scope_hostname: Optional[str],
+    cache_dir: str,
+    concurrency: int,
+    no_issues: bool,
+) -> None:
+    in_scope_hostname = in_scope_hostname or site_label
+    links = _collect_links_from_cache(cache_dir)
+    if not links:
+        _print("No links found in cached HTML - nothing to check")
+        return
+    _print(f"Discovered {len(links)} unique link URL(s) to check")
+
+    errors = _check_links_concurrently(links, concurrency)
+    errors_by_status: Dict[int, List[Dict]] = defaultdict(list)
+    for err in errors:
+        errors_by_status[err["status_code"]].append(err)
+
+    if not errors_by_status:
+        _print(f"All {len(links)} link(s) returned non-reportable statuses")
+        return
+
+    _print(f"Reportable errors: {len(errors)}")
+    for status, records in sorted(errors_by_status.items()):
+        _print(f"  {status}: {len(records)} URL(s)")
+
+    if no_issues:
+        for status, records in sorted(errors_by_status.items()):
+            for r in records:
+                _print(
+                    f"  {status}  {r['url']}  found on {len(r['containing_pages'])} page(s)"
+                )
+        return
+
+    action_url = (
+        f"{GITHUB_SERVER_URL}/{GITHUB_REPOSITORY}/actions/runs/{GITHUB_RUN_ID}/"
+    )
+    current_issues = _get_current_github_issues()
+    opened: List[str] = []
+    for status, records in sorted(errors_by_status.items()):
+        issue_url = _open_issue_for_status_code(
+            site_label=site_label,
+            status_code=status,
+            error_records=records,
+            action_url=action_url,
+            in_scope_hostname=in_scope_hostname,
+            current_issues=current_issues,
+        )
+        if issue_url:
+            opened.append(issue_url)
+
+    message_parts = [
+        f"Broken outbound link(s) found while scanning {site_label}.",
+        f"Details and output: {action_url}",
+    ]
+    if opened:
+        message_parts.append("Issue(s) opened:\n" + "\n".join(opened))
+    else:
+        message_parts.append(
+            "NB: No new issues opened - existing open issues already track these findings."
+        )
+    message = "\n".join(message_parts)
+    _print(message)
+    ping_slack(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_links_in_cached_pages.py
+++ b/tests/test_check_links_in_cached_pages.py
@@ -1,0 +1,241 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from unittest.mock import MagicMock, patch
+
+from bin.check_links_in_cached_pages import (
+    _build_issue_body,
+    _check_url,
+    _collect_links_from_cache,
+    _filename_to_url,
+    _is_reportable_status,
+    _redact_page_url,
+    _site_scoped_fingerprint,
+    _strip_fragment,
+)
+
+
+class TestFilenameToUrl:
+    def test_path_ending_in_slash_round_trips(self):
+        # encoded form of https://www.mozilla.org/en-US/firefox/
+        assert (
+            _filename_to_url("https%3A__www.mozilla.org_en-US_firefox_.html")
+            == "https://www.mozilla.org/en-US/firefox/"
+        )
+
+    def test_path_with_natural_html_extension_preserves_html(self):
+        # encoded form of https://www.mozilla.org/en-US/security/advisories/mfsa2024-01.html
+        assert (
+            _filename_to_url(
+                "https%3A__www.mozilla.org_en-US_security_advisories_mfsa2024-01.html"
+            )
+            == "https://www.mozilla.org/en-US/security/advisories/mfsa2024-01.html"
+        )
+
+    def test_path_without_html_or_slash(self):
+        # encoded form of http://localhost:8000/en-US
+        assert (
+            _filename_to_url("http%3A__localhost%3A8000_en-US")
+            == "http://localhost:8000/en-US"
+        )
+
+
+class TestIsReportableStatus:
+    def test_404_is_reportable(self):
+        assert _is_reportable_status(404) is True
+
+    def test_5xx_is_reportable(self):
+        for code in (500, 502, 503, 504, 599):
+            assert _is_reportable_status(code) is True
+
+    def test_2xx_3xx_not_reportable(self):
+        for code in (200, 201, 204, 301, 302, 304):
+            assert _is_reportable_status(code) is False
+
+    def test_other_4xx_not_reportable(self):
+        # 403/429 are common bot-blocking responses; we don't report them
+        for code in (400, 401, 403, 410, 429):
+            assert _is_reportable_status(code) is False
+
+
+class TestStripFragment:
+    def test_drops_fragment(self):
+        assert (
+            _strip_fragment("https://example.com/path?q=1#section")
+            == "https://example.com/path?q=1"
+        )
+
+    def test_leaves_fragmentless_url_unchanged(self):
+        assert (
+            _strip_fragment("https://example.com/path?q=1")
+            == "https://example.com/path?q=1"
+        )
+
+
+class TestRedactPageUrl:
+    def test_same_host_strips_scheme_and_netloc(self):
+        assert (
+            _redact_page_url(
+                "https://www.mozilla.org/en-US/firefox/", "www.mozilla.org"
+            )
+            == "/en-US/firefox/"
+        )
+
+    def test_same_host_preserves_query_string(self):
+        assert (
+            _redact_page_url("https://www.mozilla.org/page?q=1", "www.mozilla.org")
+            == "/page?q=1"
+        )
+
+    def test_different_host_leaves_url_intact(self):
+        assert (
+            _redact_page_url("https://example.com/foo", "www.mozilla.org")
+            == "https://example.com/foo"
+        )
+
+
+class TestSiteScopedFingerprint:
+    def test_different_site_labels_produce_different_hashes_for_same_urls(self):
+        urls = ["https://example.org/dead"]
+        mozorg_fp = _site_scoped_fingerprint("www.mozilla.org", urls)
+        firefox_fp = _site_scoped_fingerprint("www.firefox.com", urls)
+        assert mozorg_fp != firefox_fp
+
+    def test_url_order_does_not_affect_hash(self):
+        assert _site_scoped_fingerprint(
+            "site", ["b", "a", "c"]
+        ) == _site_scoped_fingerprint("site", ["a", "b", "c"])
+
+
+class TestCollectLinksFromCache:
+    def _write_page(self, tmp_path, filename, html):
+        (tmp_path / filename).write_text(html)
+
+    def test_extracts_anchor_script_link_tags(self, tmp_path):
+        html = """
+        <html><head>
+        <link rel="stylesheet" href="/styles.css">
+        <script src="https://cdn.example.com/lib.js"></script>
+        </head><body>
+        <a href="https://example.org/dead">dead</a>
+        <a href="/en-US/about/">about</a>
+        </body></html>
+        """
+        self._write_page(
+            tmp_path, "https%3A__www.mozilla.org_en-US_firefox_.html", html
+        )
+
+        links = _collect_links_from_cache(str(tmp_path))
+
+        # Relative hrefs resolved against the page URL
+        assert "https://www.mozilla.org/styles.css" in links
+        assert "https://cdn.example.com/lib.js" in links
+        assert "https://example.org/dead" in links
+        assert "https://www.mozilla.org/en-US/about/" in links
+
+    def test_records_containing_pages_per_link(self, tmp_path):
+        page_a = "<a href='https://example.org/x'>x</a>"
+        page_b = "<a href='https://example.org/x'>x again</a>"
+        self._write_page(tmp_path, "https%3A__www.mozilla.org_en-US_a_.html", page_a)
+        self._write_page(tmp_path, "https%3A__www.mozilla.org_en-US_b_.html", page_b)
+
+        links = _collect_links_from_cache(str(tmp_path))
+
+        assert links["https://example.org/x"] == {
+            "https://www.mozilla.org/en-US/a/",
+            "https://www.mozilla.org/en-US/b/",
+        }
+
+    def test_skips_mailto_tel_javascript_data_and_fragment(self, tmp_path):
+        html = """
+        <a href="mailto:user@example.com">m</a>
+        <a href="tel:+1234">t</a>
+        <a href="javascript:void(0)">j</a>
+        <a href="data:image/png;base64,XXXX">d</a>
+        <a href="#section-2">f</a>
+        <a href="">empty</a>
+        """
+        self._write_page(tmp_path, "https%3A__www.mozilla.org_en-US_x_.html", html)
+        links = _collect_links_from_cache(str(tmp_path))
+        assert links == {}
+
+    def test_strips_fragments_so_same_target_dedups(self, tmp_path):
+        html = (
+            '<a href="https://example.org/page#one">a</a>'
+            '<a href="https://example.org/page#two">b</a>'
+        )
+        self._write_page(tmp_path, "https%3A__www.mozilla.org_en-US_x_.html", html)
+        links = _collect_links_from_cache(str(tmp_path))
+        assert list(links.keys()) == ["https://example.org/page"]
+
+
+class TestCheckUrl:
+    def test_returns_head_status_when_head_succeeds(self):
+        with patch("bin.check_links_in_cached_pages.requests.head") as mock_head:
+            mock_head.return_value = MagicMock(status_code=200)
+            assert _check_url("https://example.com/") == 200
+
+    def test_falls_back_to_get_when_head_returns_405(self):
+        with (
+            patch("bin.check_links_in_cached_pages.requests.head") as mock_head,
+            patch("bin.check_links_in_cached_pages.requests.get") as mock_get,
+        ):
+            mock_head.return_value = MagicMock(status_code=405)
+            mock_get.return_value = MagicMock(status_code=200)
+            assert _check_url("https://example.com/") == 200
+            mock_get.assert_called_once()
+
+    def test_returns_404_status(self):
+        with patch("bin.check_links_in_cached_pages.requests.head") as mock_head:
+            mock_head.return_value = MagicMock(status_code=404)
+            assert _check_url("https://example.com/gone") == 404
+
+    def test_returns_none_on_transport_error(self):
+        import requests as real_requests
+
+        with patch("bin.check_links_in_cached_pages.requests.head") as mock_head:
+            mock_head.side_effect = real_requests.ConnectionError("boom")
+            assert _check_url("https://example.com/") is None
+
+    def test_retries_5xx_once_then_returns_final_status(self):
+        with (
+            patch("bin.check_links_in_cached_pages.requests.head") as mock_head,
+            patch("bin.check_links_in_cached_pages.time.sleep"),
+        ):
+            mock_head.side_effect = [
+                MagicMock(status_code=503),
+                MagicMock(status_code=503),
+            ]
+            assert _check_url("https://example.com/") == 503
+            assert mock_head.call_count == 2
+
+
+class TestBuildIssueBody:
+    def test_body_includes_urls_pages_action_url_and_fingerprint(self):
+        records = [
+            {
+                "url": "https://example.org/dead",
+                "status_code": 404,
+                "containing_pages": [
+                    "https://www.mozilla.org/en-US/firefox/",
+                    "https://www.mozilla.org/en-US/about/",
+                ],
+            }
+        ]
+        body = _build_issue_body(
+            site_label="www.mozilla.org",
+            status_code=404,
+            error_records=records,
+            action_url="https://gh/actions/run/42",
+            in_scope_hostname="www.mozilla.org",
+            fingerprint="abc123",
+        )
+        assert "https://example.org/dead" in body
+        # in-scope hostnames are redacted to path-only
+        assert "/en-US/firefox/" in body
+        assert "/en-US/about/" in body
+        assert "https://gh/actions/run/42" in body
+        assert "Fingerprint: abc123" in body
+        assert "www.mozilla.org" in body
+        assert "404 Not Found" in body


### PR DESCRIPTION
## Summary

- The existing scan only reports HTTP errors for URLs pulled from the sitemap (or `extra-urls-*.yaml`). Outbound links found on those pages are checked against the allowlist but never fetched — so 404s and 5xxs on links to other sites are invisible today.
- Adds a per-site post-scan workflow that reuses the `html-cache-*` artifacts already emitted by `scan_site.py --export-cache`, walks every cached page, fetches every `<a>` / `<script>` / `<link>` URL with HEAD (GET fallback on 405 / 501), and opens **one consolidated GitHub issue per status code (404 / 5xx)** listing the dead links and the pages they appear on.
- Coverage = en-US CDN pages, mirroring the existing geo-check pattern. External link liveness is locale-independent, so en-US is enough.
- Fingerprints are **scoped by `--site-label`** so a 404 on `https://example.org/dead` found by both `www.mozilla.org` and `www.firefox.com` opens two issues rather than one site masking the other.

### Files

- `bin/check_links_in_cached_pages.py` — new script; reuses `utils.load_html_pages` and `utils.ping_slack`; concurrent fetches via `ThreadPoolExecutor`.
- `.github/workflows/mozorg-external-link-check.yaml` — `workflow_run`-triggered on `www.mozilla.org site scanning`; downloads `html-cache-{batch}` artifacts (regex-tightened to skip Firefox cache).
- `.github/workflows/firefox-external-link-check.yaml` — sibling, downloads `html-cache-firefox-*` artifacts.
- `tests/test_check_links_in_cached_pages.py` — 24 new unit tests.

### What's deliberately not in scope

- en-US-only cache coverage. Can broaden later by widening `LOCALES_TO_CACHE` in `scan_site.py`.
- Rate-limit / 429 backoff for unfriendly external hosts.
- Existing `_create_http_error_issues()` in `handle_site_scan_output.py` has a latent same-class fingerprint-collision risk between mozorg and firefox — not introduced by this work, but worth fixing in a follow-up.

## Test plan

- [x] `pytest` — 41/41 pass (24 new)
- [x] `zizmor --pedantic .` — clean across all workflows
- [x] `pre-commit run` on touched files — clean
- [ ] Manual local sanity check: populate `page_cache/` via `scan_site.py --specific-url=... --export-cache`, run `python bin/check_links_in_cached_pages.py --site-label=www.mozilla.org --in-scope-hostname=www.mozilla.org --no-issues` and confirm reported errors look right
- [ ] After merge: confirm the new workflow triggers on the next `www.mozilla.org site scanning` run, downloads `html-cache-*` artifacts, and that any opened issues are well-formed